### PR TITLE
Add MockMvc tests for Pessoa MVC controller

### DIFF
--- a/dados-pessoais-2025/src/test/java/br/com/webmobi/dadospessoais/webmvc/PessoaMvcControllerTest.java
+++ b/dados-pessoais-2025/src/test/java/br/com/webmobi/dadospessoais/webmvc/PessoaMvcControllerTest.java
@@ -1,0 +1,161 @@
+package br.com.webmobi.dadospessoais.webmvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import br.com.webmobi.dadospessoais.dominio.UrlMapper;
+import br.com.webmobi.dadospessoais.dominio.dto.InteresseDto;
+import br.com.webmobi.dadospessoais.dominio.dto.PessoaDto;
+import br.com.webmobi.dadospessoais.dominio.dto.PessoaInclusaoDto;
+import br.com.webmobi.dadospessoais.dominio.dto.PessoaMvcDto;
+import br.com.webmobi.dadospessoais.dominio.entity.InteresseEntity;
+import br.com.webmobi.dadospessoais.dominio.entity.PessoaEntity;
+import br.com.webmobi.dadospessoais.dominio.service.InteresseService;
+import br.com.webmobi.dadospessoais.dominio.service.PessoaFotoService;
+import br.com.webmobi.dadospessoais.dominio.service.PessoaService;
+import jakarta.validation.ConstraintViolationException;
+
+@WebMvcTest(controllers = PessoaMvcController.class, excludeAutoConfiguration = {
+		OAuth2ResourceServerAutoConfiguration.class, SecurityAutoConfiguration.class })
+@AutoConfigureMockMvc
+class PessoaMvcControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private PessoaService pessoaService;
+
+	@MockitoBean
+	private PessoaFotoService pessoaFotoService;
+
+	@MockitoBean
+	private InteresseService interesseService;
+
+	@MockitoBean
+	private UrlMapper urlMapper;
+
+	private PessoaEntity criarPessoa(int id) {
+		PessoaEntity pessoaMock = new PessoaEntity();
+		pessoaMock.setId(id);
+		pessoaMock.setPublicId(UUID.randomUUID());
+		String username = "pessoa" + id;
+		pessoaMock.setUsername(username);
+		pessoaMock.setNome("Pessoa " + id);
+		pessoaMock.setEmail(username + "@email.com");
+		pessoaMock.setTelefone("(11) 99999-1234");
+		pessoaMock.setDataNascimento(LocalDate.parse("2000-05-20"));
+		Instant now = Instant.now();
+		pessoaMock.setDataCriacao(now);
+		pessoaMock.setDataAtualizacao(now);
+		pessoaMock.setInteresses(new HashSet<>(List.of(new InteresseEntity(1, "Java"), new InteresseEntity(2, "Web"))));
+		return pessoaMock;
+	}
+
+	private PessoaMvcDto criarPessoaMvcDto(UUID publicId) {
+		return new PessoaMvcDto(publicId, "fulano", "Fulano da Silva", "fulano@email.com", "(11) 99999-1234",
+				LocalDate.parse("2000-05-20"), List.of(1, 2));
+	}
+
+	@Test
+	void listarDeveRetornarPaginaComItens() throws Exception {
+		given(pessoaService.listar(any(Pageable.class)))
+				.willReturn(new PageImpl<>(List.of(new PessoaDto(criarPessoa(1)))));
+
+		mockMvc.perform(get("/mvc/pessoas")).andExpect(status().isOk())
+				.andExpect(view().name("pessoas/lista")).andExpect(model().attributeExists("itens"));
+	}
+
+	@Test
+	void incluirFormDeveRetornarFormulario() throws Exception {
+		given(interesseService.listarTudo()).willReturn(List.of(new InteresseDto(1, "Java")));
+
+		mockMvc.perform(get("/mvc/pessoas/incluir")).andExpect(status().isOk())
+				.andExpect(view().name("pessoas/form")).andExpect(model().attributeExists("item"))
+				.andExpect(model().attributeExists("opcoesInteresses"));
+	}
+
+	@Test
+	void alterarFormDeveRetornarFormularioComItem() throws Exception {
+		UUID publicId = UUID.randomUUID();
+		given(pessoaService.buscarPorIdMvc(publicId)).willReturn(criarPessoaMvcDto(publicId));
+		given(interesseService.listarTudo()).willReturn(List.of(new InteresseDto(1, "Java")));
+
+		mockMvc.perform(get("/mvc/pessoas/{id}/alterar", publicId)).andExpect(status().isOk())
+				.andExpect(view().name("pessoas/form")).andExpect(model().attributeExists("item"))
+				.andExpect(model().attributeExists("opcoesInteresses"));
+	}
+
+	@Test
+	void incluirNovoDeveRedirecionarQuandoSucesso() throws Exception {
+		PessoaEntity pessoa = criarPessoa(1);
+		given(pessoaService.incluirNovo(any(PessoaInclusaoDto.class))).willReturn(new PessoaDto(pessoa));
+
+		mockMvc.perform(post("/mvc/pessoas/incluir").param("username", "fulano").param("nome", "Fulano da Silva")
+				.param("email", "fulano@email.com").param("telefone", "(11) 99999-1234")
+				.param("dataNascimento", "2000-05-20").param("senha", "Abcd1234")
+				.param("senhaConfirmacao", "Abcd1234").param("interessesIds", "1", "2"))
+				.andExpect(status().is3xxRedirection()).andExpect(view().name("redirect:/mvc/pessoas"))
+				.andExpect(flash().attributeExists("msg"));
+	}
+
+	@Test
+	void incluirNovoDeveRetornarFormularioQuandoErroValidacao() throws Exception {
+		given(interesseService.listarTudo()).willReturn(List.of(new InteresseDto(1, "Java")));
+		given(pessoaService.incluirNovo(any(PessoaInclusaoDto.class)))
+				.willThrow(new ConstraintViolationException(Set.of()));
+
+		mockMvc.perform(post("/mvc/pessoas/incluir").param("username", "fulano").param("nome", "Fulano da Silva")
+				.param("email", "fulano@email.com").param("telefone", "(11) 99999-1234")
+				.param("dataNascimento", "2000-05-20").param("senha", "Abcd1234")
+				.param("senhaConfirmacao", "Abcd1234").param("interessesIds", "1", "2"))
+				.andExpect(status().isOk()).andExpect(view().name("pessoas/form"))
+				.andExpect(model().attributeExists("opcoesInteresses"));
+	}
+
+	@Test
+	void alterarDeveRedirecionarQuandoSucesso() throws Exception {
+		UUID publicId = UUID.randomUUID();
+		PessoaEntity pessoa = criarPessoa(1);
+		given(pessoaService.alterar(any(UUID.class), any())).willReturn(new PessoaDto(pessoa));
+
+		mockMvc.perform(post("/mvc/pessoas/{id}/alterar", publicId).param("username", "fulano")
+				.param("nome", "Fulano da Silva").param("email", "fulano@email.com")
+				.param("telefone", "(11) 99999-1234").param("dataNascimento", "2000-05-20")
+				.param("interessesIds", "1", "2"))
+				.andExpect(status().is3xxRedirection()).andExpect(view().name("redirect:/mvc/pessoas"))
+				.andExpect(flash().attributeExists("msg"));
+	}
+
+	@Test
+	void excluirDeveRedirecionarQuandoSucesso() throws Exception {
+		UUID publicId = UUID.randomUUID();
+
+		mockMvc.perform(post("/mvc/pessoas/{id}/excluir", publicId)).andExpect(status().is3xxRedirection())
+				.andExpect(view().name("redirect:/mvc/pessoas")).andExpect(flash().attributeExists("msg"));
+	}
+}

--- a/dados-pessoais-2025/src/test/java/br/com/webmobi/dadospessoais/webmvc/PessoaMvcControllerTest.java
+++ b/dados-pessoais-2025/src/test/java/br/com/webmobi/dadospessoais/webmvc/PessoaMvcControllerTest.java
@@ -2,9 +2,14 @@ package br.com.webmobi.dadospessoais.webmvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
@@ -26,10 +31,12 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mock.web.MockMultipartFile;
 
 import br.com.webmobi.dadospessoais.dominio.UrlMapper;
 import br.com.webmobi.dadospessoais.dominio.dto.InteresseDto;
 import br.com.webmobi.dadospessoais.dominio.dto.PessoaDto;
+import br.com.webmobi.dadospessoais.dominio.dto.PessoaFotoDto;
 import br.com.webmobi.dadospessoais.dominio.dto.PessoaInclusaoDto;
 import br.com.webmobi.dadospessoais.dominio.dto.PessoaMvcDto;
 import br.com.webmobi.dadospessoais.dominio.entity.InteresseEntity;
@@ -152,10 +159,47 @@ class PessoaMvcControllerTest {
 	}
 
 	@Test
+	void alterarDeveRetornarFormularioQuandoErroValidacao() throws Exception {
+		UUID publicId = UUID.randomUUID();
+		given(interesseService.listarTudo()).willReturn(List.of(new InteresseDto(1, "Java")));
+		given(pessoaService.alterar(any(UUID.class), any())).willThrow(new ConstraintViolationException(Set.of()));
+
+		mockMvc.perform(post("/mvc/pessoas/{id}/alterar", publicId).param("username", "fulano")
+				.param("nome", "Fulano da Silva").param("email", "fulano@email.com")
+				.param("telefone", "(11) 99999-1234").param("dataNascimento", "2000-05-20")
+				.param("interessesIds", "1", "2"))
+				.andExpect(status().isOk()).andExpect(view().name("pessoas/form"))
+				.andExpect(model().attributeExists("opcoesInteresses"));
+	}
+
+	@Test
 	void excluirDeveRedirecionarQuandoSucesso() throws Exception {
 		UUID publicId = UUID.randomUUID();
 
 		mockMvc.perform(post("/mvc/pessoas/{id}/excluir", publicId)).andExpect(status().is3xxRedirection())
 				.andExpect(view().name("redirect:/mvc/pessoas")).andExpect(flash().attributeExists("msg"));
+	}
+
+	@Test
+	void incluirFotoDeveRetornarCreated() throws Exception {
+		UUID publicId = UUID.randomUUID();
+		MockMultipartFile arquivo = new MockMultipartFile("arquivo", "foto.jpg", "image/jpeg", "conteudo".getBytes());
+		given(pessoaFotoService.salvar(any(UUID.class), any()))
+				.willReturn(new PessoaFotoDto("foto.jpg", "Legenda"));
+		given(urlMapper.getImagemUrlPath(publicId, "foto.jpg")).willReturn("/uploads/" + publicId + "/fotos/foto.jpg");
+
+		mockMvc.perform(multipart("/mvc/pessoas/{pessoaId}/fotos", publicId).file(arquivo).param("legenda", "Legenda"))
+				.andExpect(status().isCreated()).andExpect(header().string("Location",
+						"http://localhost/uploads/" + publicId + "/fotos/foto.jpg"));
+	}
+
+	@Test
+	void excluirFotoDeveRetornarNoContent() throws Exception {
+		UUID publicId = UUID.randomUUID();
+
+		mockMvc.perform(delete("/mvc/pessoas/{pessoaId}/fotos/{nomeArquivo}", publicId, "foto.jpg"))
+				.andExpect(status().isNoContent());
+
+		then(pessoaFotoService).should(times(1)).excluir(publicId, "foto.jpg");
 	}
 }


### PR DESCRIPTION
### Motivation
- Add automated tests covering the traditional MVC flows for the `Pessoa` feature to increase confidence in controller behavior.
- Ensure both success and validation-error paths are covered for create/update/delete/list/form endpoints.

### Description
- Add a new test class `src/test/java/br/com/webmobi/dadospessoais/webmvc/PessoaMvcControllerTest.java` with MockMvc-based tests.
- Use `@WebMvcTest` (excluding security auto-configuration), `@AutoConfigureMockMvc`, and `@MockitoBean` to mock dependencies such as `PessoaService`, `InteresseService`, `PessoaFotoService`, and `UrlMapper`.
- Provide helper factory methods `criarPessoa` and `criarPessoaMvcDto` to build test entities/DTOs and cover scenarios.
- Include tests for listing (`/mvc/pessoas`), showing include/alter forms, successful create and update (redirect with flash), create validation failure (returns form), and successful delete (redirect with flash).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fb8e796388326a880dcdde946d39d)